### PR TITLE
Replace omahaproxy and add Win_Arm64

### DIFF
--- a/src/constants/chromium.ts
+++ b/src/constants/chromium.ts
@@ -4,6 +4,7 @@ export const OSList: Os[] = [
   { val: 'Mac', file: 'chrome-mac.zip' },
   { val: 'Mac_Arm', file: 'chrome-mac.zip' },
   { val: 'Win_x64', file: 'chrome-win.zip' },
+  { val: 'Win_Arm64', file: 'chrome-win.zip' },
   { val: 'Win', file: 'chrome-win32.zip' },
   { val: 'Linux_x64', file: 'chrome-linux.zip' },
   { val: 'Linux', file: 'chrome-linux.zip' },

--- a/src/constants/chromium.ts
+++ b/src/constants/chromium.ts
@@ -23,8 +23,8 @@ export const Links = [
     href: 'https://chromium.googlesource.com/chromium/src/+refs',
   },
   {
-    name: 'Official Look Up Page (omahaproxy)',
-    href: 'https://omahaproxy.appspot.com/',
+    name: 'Official Look Up Page (chromiumdash)',
+    href: 'https://chromiumdash.appspot.com/',
   },
   {
     name: 'Official Download Page',
@@ -72,8 +72,8 @@ export const Explains = [
         href: 'https://chromium.googlesource.com/chromium/src/+refs',
       },
       {
-        text: 'find a position number by version (there is an api from https://omahaproxy.appspot.com/)',
-        href: 'https://omahaproxy.appspot.com/deps.json?version=86.0.4240.63',
+        text: 'find a position number by version (there is an api from https://chromiumdash.appspot.com/)',
+        href: 'https://chromiumdash.appspot.com/fetch_version?version=91.0.4472.169',
       },
       {
         text: 'loop all positions of the OS(e.g. Mac), find out if exist in step2 data',


### PR DESCRIPTION
- Replaces `omahaproxy` links and references with `chromiumdash` .
- Add `Win_Arm64` to `OSList`
